### PR TITLE
GPWEBFLOW-93: Update to Web Flow 2.4.1

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -19,7 +19,7 @@ grails.project.dependency.resolution = {
 
     dependencies {
         compile 'org.grails:grails-web-databinding-spring:2.4.0'
-        compile('org.springframework.webflow:spring-webflow:2.4.0.RELEASE') {
+        compile('org.springframework.webflow:spring-webflow:2.4.1.RELEASE') {
             exclude group:"org.springframework", name:"spring-beans"
             exclude group:"org.springframework", name:"spring-expression"
             exclude group:"org.springframework", name:"spring-context"


### PR DESCRIPTION
Web Flow 2.4.1 works with both Hibernate 3 and Hibernate 4. See https://jira.grails.org/browse/GPWEBFLOW-93
