### PR TITLE
Global transition support

### DIFF
--- a/test/unit/org/codehaus/groovy/grails/webflow/engine/builder/GlobalTransitionTests.groovy
+++ b/test/unit/org/codehaus/groovy/grails/webflow/engine/builder/GlobalTransitionTests.groovy
@@ -1,0 +1,52 @@
+package org.codehaus.groovy.grails.webflow.engine.builder
+
+import org.codehaus.groovy.grails.webflow.support.AbstractGrailsTagAwareFlowExecutionTests
+
+class GlobalTransitionTests extends AbstractGrailsTagAwareFlowExecutionTests {
+
+    Closure getFlowClosure() {
+        return {
+
+            globalTransitions {
+                on("globalEnterPersonalDetails").to("enterPersonalDetails")
+                on("globalEnterShipping").to("enterShipping")
+            }
+
+            enterPersonalDetails {
+                on("submit") { ctx ->
+                    error()
+                }.to "enterShipping"
+                on("another") { ctx ->
+                    ctx.flowScope.put("hello", "world")
+                }.to "enterShipping"
+            }
+            enterShipping {
+                on("back").to "enterPersonalDetails"
+                on("submit").to "displayInvoice"
+            }
+            displayInvoice()
+        }
+    }
+
+    void testFlowExecution() {
+        startFlow()
+        assertCurrentStateEquals "enterPersonalDetails"
+
+        signalEvent("submit")
+        assertCurrentStateEquals "enterPersonalDetails"
+
+        signalEvent("another")
+        assertCurrentStateEquals "enterShipping"
+
+        signalEvent("globalEnterPersonalDetails")
+        assertCurrentStateEquals "enterPersonalDetails"
+
+        signalEvent("globalEnterShipping")
+        assertCurrentStateEquals "enterShipping"
+
+        signalEvent("globalEnterPersonalDetails")
+        assertCurrentStateEquals "enterPersonalDetails"
+
+    }
+
+}


### PR DESCRIPTION
This PR adds support for global transitions to the Grails webflow plugin. It modifies the FlowBuilder to recognise a named closure 'globalTransitions' which uses an instance of new class GlobalTransitionCapturer as it's delegate. This delegate captures transitions via three to() methods copied from the existing FlowInfoCapturer, and injects any captured transitions into the Flow's global transition set. An example of it's usage is in the supplied unit test 